### PR TITLE
Remove the header on the launch screen

### DIFF
--- a/generators/base/templates/App/Router.react-navigation.js
+++ b/generators/base/templates/App/Router.react-navigation.js
@@ -12,6 +12,9 @@ import Scenes from '<%= name %>/App/Scenes';
 const RootNavigator = StackNavigator({
   Launch: {
     screen: Scenes.Launch,
+    navigationOptions: {
+      header: null
+    }
   },
   Main: {
     screen: Scenes.Main,


### PR DESCRIPTION
This only applies if you choose `react-navigation` as your router.