### PR TITLE
Prettier

### DIFF
--- a/generators/base/index.js
+++ b/generators/base/index.js
@@ -298,6 +298,7 @@ module.exports = class extends Generator {
     this.yarnInstall([
       'flow-bin@',
       'prettier',
+      'https://github.com/simpleweb/configs.git',
     ], {
       'dev': true
     });

--- a/generators/base/templates/package.json
+++ b/generators/base/templates/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "scripts": {
-    "prettier": "prettier --write './App/**/*.js'"
+    "prettier": "prettier --config ./node_modules/@simpleweb/configs/.prettierrc --write './App/**/*.js'"
   }
 }


### PR DESCRIPTION
This adds a task that can be run from the `yarn` (`yarn run prettier`) and executes it upon installation so that all the code is formatted with Prettier.

This fixes #6 