### PR TITLE
Remove manual edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,17 +95,6 @@ yo react-native:reducer MyReducer
 
 The default `react-native init` now comes with tvOS targets... These add un-needed cruft to the project. Best plan is to open the XCode project, remove the tvOS targets and then delete the files in the project themselves.
 
-Add the following to your `.gitignore`.
-
-```
-# Enviroments
-.env
-.env.development
-.env.staging
-.env.live
-.env.production
-```
-
 Follow the Android version of these instructions to add automatic build numbers.
 
 [https://medium.com/@andr3wjack/versioning-react-native-apps-407469707661#.quhgn05gf](https://medium.com/@andr3wjack/versioning-react-native-apps-407469707661#.quhgn05gf)

--- a/generators/base/index.js
+++ b/generators/base/index.js
@@ -302,6 +302,7 @@ module.exports = class extends Generator {
 
   end() {
     this.spawnCommandSync('yarn', ['run', 'prettier']);
+    this.spawnCommandSync('yarn', ['run', 'updateignore']);
     this.log('Setup complete!');
     this.log('Please refer to the post-install notes');
     this.log('https://github.com/simpleweb/generator-react-native#after-react-nativebase');

--- a/generators/base/templates/bin/gitignore.sh
+++ b/generators/base/templates/bin/gitignore.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash -e
+
+echo "" >> .gitignore;
+echo "# Environments" >> .gitignore;
+echo ".env*" >> .gitignore;

--- a/generators/base/templates/package.json
+++ b/generators/base/templates/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "scripts": {
     "prettier": "prettier --config ./node_modules/@simpleweb/configs/.prettierrc --write './App/**/*.js'",
+    "updateignore": "./bin/gitignore.sh",
     "version": "./bin/version-ios.sh",
     "test": "jest --verbose",
     "coverage": "jest --coverage",


### PR DESCRIPTION
This removes the need to manually edit the `package.json` for additional scripts and adding env files to the `.gitignore`.