### PR TITLE
Fixing undefined token for import, for a stateful component.

### DIFF
--- a/generators/component/templates/stateful.js
+++ b/generators/component/templates/stateful.js
@@ -1,5 +1,5 @@
 // @flow
-import * from React from 'react';
+import * as React from 'react';
 import { View, Text } from './styles';
 
 type State = {


### PR DESCRIPTION
Undefined token, when a new stateful component is created. Simple fix.
