### PR TITLE
Remove Native Ref from Styled-Components import

### DIFF
--- a/generators/component/templates/styles.js
+++ b/generators/component/templates/styles.js
@@ -1,5 +1,5 @@
 // @flow
-import styled from "styled-components/native";
+import styled from "styled-components";
 
 export const View = styled.View``;
 


### PR DESCRIPTION
* Remove `native` ref, as is now deprecated in v3