### PR TITLE
Babel Fix for RNDotEnv

### DIFF
--- a/generators/base/templates/.babelrc
+++ b/generators/base/templates/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["react-native", "react-native-dotenv"]
+  "presets": ["react-native", "module:react-native-dotenv"]
 }


### PR DESCRIPTION
As we are always using the latest version of RN, we need to make this change as [mentioned](https://github.com/zetachang/react-native-dotenv#rn-056-babel-7) in their docs.