### PR TITLE
iPhone X environment label fix and normal positioning tweak

### DIFF
--- a/generators/base/index.js
+++ b/generators/base/index.js
@@ -241,6 +241,7 @@ module.exports = class extends Generator {
       'axios',
       'react-native-config',
       'react-navigation@1.5.11',
+      'react-native-iphone-x-helper',
       'react-redux',
       'redux',
       'redux-action-buffer',

--- a/generators/base/templates/App/Components/Utilities/Environment/styles.js
+++ b/generators/base/templates/App/Components/Utilities/Environment/styles.js
@@ -1,8 +1,10 @@
 // @flow
-import styled from 'styled-components';
-import variables from '<%= name %>/App/Styles/Variables';
+import styled, { css } from "styled-components";
+import { isIphoneX } from "react-native-iphone-x-helper";
+import variables from "<%= name %>/App/Styles/Variables";
+import RNText from "<%= name %>/App/Components/Text";
 
-import RNText from '<%= name %>/App/Components/Text';
+const SAFE_AREA_BOTTOM = 34;
 
 const envCheck = env => {
   switch (env) {
@@ -22,8 +24,12 @@ export const Badge = styled.View`
   height: 18px;
   background-color: ${props => envCheck(props.env)};
   position: absolute;
-  right: 5px;
-  bottom: 5px;
+  right: 8px;
+  bottom: 8px;
+  ${isIphoneX() &&
+    css`
+      bottom: ${SAFE_AREA_BOTTOM + 8}px;
+    `};
   justify-content: center;
   align-items: center;
   border-radius: 4;
@@ -31,7 +37,7 @@ export const Badge = styled.View`
 
 export const Text = styled(RNText)`
   font-size: 12;
-  font-family: 'System';
+  font-family: "System";
   font-weight: bold;
   color: ${variables.colors.white};
 `;


### PR DESCRIPTION
Repositions the the environment indicator the iphone x

This fixes #43 

<img width="273" alt="screen shot 2018-08-16 at 12 20 33" src="https://user-images.githubusercontent.com/713128/44205642-e9fd1b00-a14e-11e8-82b1-ce69e0f908d2.png">
<img width="273" alt="screen shot 2018-08-16 at 11 49 09" src="https://user-images.githubusercontent.com/713128/44205643-e9fd1b00-a14e-11e8-8a00-5b531dd9af66.png">
