### PR TITLE
Fix for styled-components v4

### DIFF
--- a/generators/base/templates/App/Components/Layout/styles.js
+++ b/generators/base/templates/App/Components/Layout/styles.js
@@ -30,7 +30,7 @@ export const CenterView = styled.View`
   align-items: center;
 `;
 
-export const CenterVerticallyView = FullView.extend`
+export const CenterVerticallyView = styled(FullView)`
   justify-content: center;
 `;
 


### PR DESCRIPTION
## Proposed changes

Extend was removed in v4, this is required to change or it won’t build.