### PR TITLE
Babelrc fix

### DIFF
--- a/generators/base/index.js
+++ b/generators/base/index.js
@@ -218,11 +218,6 @@ module.exports = class extends Generator {
     );
 
     this.fs.copy(
-      this.templatePath('.babelrc'),
-      this.destinationPath('.babelrc')
-    );
-
-    this.fs.copy(
       this.templatePath('App/Assets'),
       this.destinationPath('App/Assets')
     );

--- a/generators/base/templates/.babelrc
+++ b/generators/base/templates/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["react-native"]
-}


### PR DESCRIPTION
## Proposed changes

Allow the Babel file that comes over from `react-native init` rather than our custom one as it has changed over time.
