### PR TITLE
Add DEV persistence key

### DIFF
--- a/generators/base/templates/.env
+++ b/generators/base/templates/.env
@@ -1,3 +1,4 @@
 ENV=<%= env %>
 API_URL=<%= api_url %>
 STORAGE_PREFIX=<%= storage_prefix %>
+NAVIGATION_PERSIST_KEY=NavigationStateDEV

--- a/generators/base/templates/App/App.js
+++ b/generators/base/templates/App/App.js
@@ -4,7 +4,7 @@ import { Platform } from "react-native";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/lib/integration/react";
 import { ThemeProvider } from "styled-components";
-import { ENV, NAVIGATION_PERSIST_KEY } from "SharetribeNativeDemo/App/Config";
+import { ENV, NAVIGATION_PERSIST_KEY } from "<%= name %>/App/Config";
 import Theme from "<%= name %>/App/Styles/Theme";
 import Router from "<%= name %>/App/Router";
 import { store, persistor } from "<%= name %>/App/Store";

--- a/generators/base/templates/App/App.js
+++ b/generators/base/templates/App/App.js
@@ -4,7 +4,7 @@ import { Platform } from "react-native";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/lib/integration/react";
 import { ThemeProvider } from "styled-components";
-import { ENV, NAVIGATION_PERSIST_KEY } from "<%= name %>/App/Config";
+import { NAVIGATION_PERSIST_KEY } from "<%= name %>/App/Config";
 import Theme from "<%= name %>/App/Styles/Theme";
 import Router from "<%= name %>/App/Router";
 import { store, persistor } from "<%= name %>/App/Store";
@@ -12,7 +12,7 @@ import { runSagaMiddleware } from "<%= name %>/App/Store/Middleware/Saga";
 import App from "<%= name %>/App/Components/App";
 
 const navigationPersistenceKey =
-  ENV === "development" ? NAVIGATION_PERSIST_KEY : null;
+  __DEV__ ? NAVIGATION_PERSIST_KEY : null;
 
 const prefix =
   Platform.OS === "android" ? "<%= name %>://<%= name %>/" : "<%= name %>://";

--- a/generators/base/templates/App/App.js
+++ b/generators/base/templates/App/App.js
@@ -4,11 +4,15 @@ import { Platform } from "react-native";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/lib/integration/react";
 import { ThemeProvider } from "styled-components";
+import { ENV, NAVIGATION_PERSIST_KEY } from "SharetribeNativeDemo/App/Config";
 import Theme from "<%= name %>/App/Styles/Theme";
 import Router from "<%= name %>/App/Router";
 import { store, persistor } from "<%= name %>/App/Store";
 import { runSagaMiddleware } from "<%= name %>/App/Store/Middleware/Saga";
 import App from "<%= name %>/App/Components/App";
+
+const navigationPersistenceKey =
+  ENV === "development" ? NAVIGATION_PERSIST_KEY : null;
 
 const prefix =
   Platform.OS === "android" ? "<%= name %>://<%= name %>/" : "<%= name %>://";
@@ -24,7 +28,10 @@ class <%= name %> extends React.Component<{}> {
               onBeforeLift={runSagaMiddleware}
               persistor={persistor}
             >
-              <Router uriPrefix={prefix} />
+              <Router
+                uriPrefix={prefix}
+                persistenceKey={navigationPersistenceKey}
+              />
             </PersistGate>
           </Provider>
         </App>

--- a/generators/base/templates/App/Config/index.js
+++ b/generators/base/templates/App/Config/index.js
@@ -4,5 +4,6 @@ import Config from "react-native-config";
 export const ENV = Config.ENV;
 export const API_URL = Config.API_URL;
 export const STORAGE_PREFIX = Config.STORAGE_PREFIX;
+export const NAVIGATION_PERSIST_KEY = Config.NAVIGATION_PERSIST_KEY;
 
 export default Config;


### PR DESCRIPTION
## Proposed changes

Add an optional `NAVIGATION_PERSIST_KEY` to the `.env` in order for developers to persist the currently viewed Screen after reloading the app.

## Checklist

- [x] Read the [contributing](.github/CONTRIBUTING.md) guidelines
- [x] Update the `README.md` if you think it’s necessary
- [x] Make sure the documentation reflects the changes you’ve made

![persistencekey-demo](https://user-images.githubusercontent.com/1177460/51547859-02d8cd80-1e5f-11e9-88b3-2be5cfb34792.gif)
