### PR TITLE
Default reducer tests

### DIFF
--- a/generators/base/index.js
+++ b/generators/base/index.js
@@ -56,6 +56,9 @@ module.exports = class extends Generator {
 
     // remove Flow configuration
     this.fs.delete('.flowconfig');
+    
+    // remove default test
+    this.fs.delete('__tests__/App-test.js');
 
     // copy root app file that the entry points use
     this.fs.copyTpl(

--- a/generators/base/templates/@types/index.d.ts
+++ b/generators/base/templates/@types/index.d.ts
@@ -1,3 +1,3 @@
-type ExampleType = {
-  title: string;
-};
+interface ReducerAction {
+  type: string;
+}

--- a/generators/base/templates/App/Actions/App.test.ts
+++ b/generators/base/templates/App/Actions/App.test.ts
@@ -1,0 +1,9 @@
+import { appInstalled } from "./App";
+
+it("appInstalled() should return correct action", () => {
+  const action = {
+    type: "TestingApp/APP_INSTALLED",
+  };
+
+  expect(appInstalled()).toEqual(action);
+});

--- a/generators/base/templates/App/Actions/App.test.ts
+++ b/generators/base/templates/App/Actions/App.test.ts
@@ -2,7 +2,7 @@ import { appInstalled } from "./App";
 
 it("appInstalled() should return correct action", () => {
   const action = {
-    type: "TestingApp/APP_INSTALLED",
+    type: "<%= name %>/APP_INSTALLED",
   };
 
   expect(appInstalled()).toEqual(action);

--- a/generators/base/templates/App/Actions/App.ts
+++ b/generators/base/templates/App/Actions/App.ts
@@ -1,11 +1,9 @@
 export const APP_INSTALLED = "<%= name %>/APP_INSTALLED";
 
-interface AppInstalled {
-  type: typeof APP_INSTALLED;
-}
-
-export const appInstalled = (): AppInstalled => ({
-  type: APP_INSTALLED,
+export const appInstalled = () => ({
+  type: APP_INSTALLED as typeof APP_INSTALLED,
 });
+
+type AppInstalled = ReturnType<typeof appInstalled>;
 
 export type AppActions = AppInstalled;

--- a/generators/base/templates/App/Reducers/App.test.ts
+++ b/generators/base/templates/App/Reducers/App.test.ts
@@ -9,7 +9,7 @@ it("should render an initial state", () => {
 });
 
 it("should handle APP_INSTALLED", () => {
-  const actionType = "TestingApp/APP_INSTALLED";
+  const actionType = "<%= name %>/APP_INSTALLED";
   const initialState = {
     installed: false,
   };

--- a/generators/base/templates/App/Reducers/App.test.ts
+++ b/generators/base/templates/App/Reducers/App.test.ts
@@ -1,0 +1,24 @@
+import reducer from "./App";
+
+it("should render an initial state", () => {
+  const expectedState = {
+    installed: false,
+  };
+
+  expect(reducer(undefined, { type: "" })).toEqual(expectedState);
+});
+
+it("should handle APP_INSTALLED", () => {
+  const actionType = "TestingApp/APP_INSTALLED";
+  const initialState = {
+    installed: false,
+  };
+  const action: { type: typeof actionType } = {
+    type: actionType,
+  };
+  const expectedState = {
+    installed: true,
+  };
+
+  expect(reducer(initialState, action)).toEqual(expectedState);
+});

--- a/generators/base/templates/App/Reducers/App.ts
+++ b/generators/base/templates/App/Reducers/App.ts
@@ -8,7 +8,10 @@ const initialState: State = {
   installed: false,
 };
 
-const reducer = (state = initialState, action: AppActions): State => {
+const reducer = (
+  state = initialState,
+  action: AppActions | ReducerAction,
+): State => {
   switch (action.type) {
     case APP_INSTALLED:
       return {


### PR DESCRIPTION
## Proposed changes
Adds some default example tests for the reducers and actions.

There’s also improvements for adding types to reducer actions that removes some of the TypeScript boiler plate by utilising `ReturnType`.

There’s a couple of different ways to structure the tests, in a `__tests__` folder with a mirrored directory structure or placing them inline as `*.test.ts`. We’re looking at going for having them inline which associates the unit test code with the actual code a bit tighter and reduces some overhead to mirroring the folder structure and it more or less removes the need to add `describe` blocks in the tests as the folder structure is already fairly self explanatory (see screenshot below). 

This is attempting to be upheld by having the imports be relative, rather than named e.g. `import reducer from "./App";`.

## Checklist

- [x] Read the [contributing](.github/CONTRIBUTING.md) guidelines
- [x] Update the `README.md` if you think it’s necessary
- [x] Make sure the documentation reflects the changes you’ve made

## Notes

![Screenshot 2020-02-10 at 11 53 07](https://user-images.githubusercontent.com/713128/74148308-120ef280-4bfd-11ea-957e-c1b4418039ed.png)

Fixes #114 