### PR TITLE
Hotfix: Ensure the keychain helper is copied over

### DIFF
--- a/generators/base/index.js
+++ b/generators/base/index.js
@@ -157,6 +157,12 @@ module.exports = class extends Generator {
       { name: this.name }
     );
 
+    this.fs.copyTpl(
+      this.templatePath("App/Helpers/Keychain.ts"),
+      this.destinationPath("App/Helpers/Keychain.ts"),
+      { name: this.name }
+    );
+
     // copy theme
     this.fs.copyTpl(
       this.templatePath("App/Theme.ts"),


### PR DESCRIPTION
## Proposed changes

Ensures that the `Keychain.ts` helper is copied over as part of the `init` command.

## Checklist

- [x] Read the [contributing](.github/CONTRIBUTING.md) guidelines
- [x] Update the `README.md` if you think it’s necessary
- [x] Make sure the documentation reflects the changes you’ve made