### PR TITLE
Feature: Remove notes regarding tvOS from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,6 @@ App/
 
 ### After `romulus init`
 
-The default `react-native init` now comes with tvOS targets... These add un-needed cruft to the project. Best plan is to open the XCode project, remove the tvOS targets and then delete the files in the project themselves.
-
 Follow the Android version of these instructions to add automatic build numbers.
 
 [https://medium.com/@andr3wjack/versioning-react-native-apps-407469707661#.quhgn05gf](https://medium.com/@andr3wjack/versioning-react-native-apps-407469707661#.quhgn05gf)


### PR DESCRIPTION
## Proposed changes

This fixes #145.

> This is no longer the case as of v0.62, which can be found in the v0.62 [release notes](https://reactnative.dev/blog/2020/03/26/version-0.62#moving-apple-tv-to-react-native-tvos). 
> 
> If tvOS is needed, then you can install the [react-native-tvos](https://github.com/react-native-tvos/react-native-tvos) package.

## Checklist

- [x] Read the [contributing](.github/CONTRIBUTING.md) guidelines
- [x] Update the `README.md` if you think it’s necessary
- [x] Make sure the documentation reflects the changes you’ve made