### PR TITLE
Hotfix: Ensure the reanimated babel plugin is being configured and used

### DIFF
--- a/generators/base/index.js
+++ b/generators/base/index.js
@@ -53,6 +53,12 @@ module.exports = class extends Generator {
       this.destinationPath(".eslintrc.js")
     );
 
+    // copy Babel config
+    this.fs.copyTpl(
+      this.templatePath("babel.config.js"),
+      this.destinationPath("babel.config.js")
+    );
+
     this.fs.copyTpl(
       this.templatePath("jest.config.js"),
       this.destinationPath("jest.config.js")

--- a/generators/base/templates/babel.config.js
+++ b/generators/base/templates/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  plugins: ["react-native-reanimated/plugin"],
+  presets: ["module:metro-react-native-babel-preset"],
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romulus-cli",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Brings structure to your React Native apps",
   "files": [
     "docs",


### PR DESCRIPTION
## Proposed changes

As per installation instructions for [react-native-reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation/#babel-plugin), this change ensures that the babel plugin is configured on installation.

## Checklist

- [x] Read the [contributing](.github/CONTRIBUTING.md) guidelines
- [x] Update the `README.md` if you think it’s necessary
- [x] Make sure the documentation reflects the changes you’ve made
