### PR TITLE
Feature: Switch to the correct `async-storage` package

### DIFF
--- a/.changeset/fast-pandas-check.md
+++ b/.changeset/fast-pandas-check.md
@@ -1,0 +1,5 @@
+---
+"romulus-cli": patch
+---
+
+Switch to the correct async-storage package

--- a/generators/base/index.js
+++ b/generators/base/index.js
@@ -310,7 +310,7 @@ module.exports = class extends Generator {
 
     this.yarnInstall([
       "@mobily/stacks",
-      "@react-native-community/async-storage",
+      "@react-native-async-storage/async-storage",
       "react-native-keychain",
       "axios",
       "react-native-config",

--- a/generators/base/templates/App/Reducers/index.ts
+++ b/generators/base/templates/App/Reducers/index.ts
@@ -1,5 +1,5 @@
 import { persistCombineReducers } from "redux-persist";
-import AsyncStorage from "@react-native-community/async-storage";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { ENV, STORAGE_PREFIX } from "<%= name %>/App/Config";
 <% reducers.forEach(function(reducer) { -%>
 import <%= reducer %> from "<%= name %>/App/Reducers/<%= reducer %>";


### PR DESCRIPTION
## Proposed changes

* The [`@react-native-community/async-storage`](https://www.npmjs.com/package/@react-native-community/async-storage) package has been deprecated and move over to a new organisation.

![](https://user-images.githubusercontent.com/996430/191916695-6f971cd1-58f2-4992-a523-7e048ea48764.png)

* Updates the dependencies to use the new package from the correct organisation `@react-native-async-storage/async-storage`
* Updates the imports using the `async-storage`

## Checklist

- [x] Read the [contributing](.github/CONTRIBUTING.md) guidelines
- [x] Update the `README.md` if you think it’s necessary
- [x] Make sure the documentation reflects the changes you’ve made
- [x] Ensure you have created a changeset if your changes need to be released.