### PR TITLE
Hotfix: Fix the import for the Router in the Main screen

### DIFF
--- a/.changeset/shiny-zoos-smell.md
+++ b/.changeset/shiny-zoos-smell.md
@@ -3,4 +3,4 @@
 ---
 
 Fix the import for the Router in the Main screen
-Imports the RootStackParamList in the screen command
+Imports the `RootStackParamList` in the screen command

--- a/.changeset/shiny-zoos-smell.md
+++ b/.changeset/shiny-zoos-smell.md
@@ -1,0 +1,6 @@
+---
+"romulus-cli": patch
+---
+
+Fix the import for the Router in the Main screen
+Imports the RootStackParamList in the screen command

--- a/generators/base/templates/App/Screens/Main.tsx
+++ b/generators/base/templates/App/Screens/Main.tsx
@@ -6,7 +6,7 @@ import { t } from "<%= name %>/App/Helpers/Translations";
 <% } -%>
 import Button from '<%= name %>/App/Components/Button';
 import Text from '<%= name %>/App/Components/Text';
-import { RootStackParamList } from "<%= name %>/App/Router";
+import { RootStackParamList } from "<%= name %>/App/Components/Router";
 
 type MainScreenNavigationProp = StackNavigationProp<RootStackParamList, "Main">;
 

--- a/generators/screen/templates/index.tsx
+++ b/generators/screen/templates/index.tsx
@@ -2,6 +2,7 @@ import { Box } from "@mobily/stacks";
 import React from "react";
 import { StackNavigationProp } from "@react-navigation/stack";
 import Text from "<%= name %>/App/Components/Text";
+import { RootStackParamList } from "<%= name %>/App/Components/Router";
 
 type <%= screen %>ScreenNavigationProp = StackNavigationProp<
   RootStackParamList,


### PR DESCRIPTION
## Proposed changes

* Fix the import for the Router in the Main screen
* Imports the `RootStackParamList` in the screen command

## Checklist

- [x] Read the [contributing](.github/CONTRIBUTING.md) guidelines
- [x] Update the `README.md` if you think it’s necessary
- [x] Make sure the documentation reflects the changes you’ve made
- [x] Ensure you have created a changeset if your changes need to be released.